### PR TITLE
Loosen QuickCheck dependency.

### DIFF
--- a/uuid/uuid.cabal
+++ b/uuid/uuid.cabal
@@ -64,7 +64,7 @@ Test-Suite testuuid
                        uuid,
                        bytestring >= 0.9 && < 0.11,
                        HUnit >=1.2 && < 1.3,
-                       QuickCheck >=2.4 && < 2.8,
+                       QuickCheck >=2.4 && < 2.9,
                        random >= 1.0.1 && < 1.2,
                        test-framework == 0.8.*,
                        test-framework-hunit == 0.3.*,


### PR DESCRIPTION
It's perfectly fine to use `QuickCheck-2.8` fix was tested in Gentoo.