### PR TITLE
Bump bytestring lower bound

### DIFF
--- a/uuid/uuid.cabal
+++ b/uuid/uuid.cabal
@@ -27,7 +27,7 @@ Extra-Source-Files:
 Library
  Build-Depends: base >=3 && < 5,
                 binary >= 0.4 && < 0.9,
-                bytestring >= 0.9 && < 0.11,
+                bytestring >= 0.10 && < 0.11,
                 cryptonite,
                 memory,
                 network-info == 0.2.*,


### PR DESCRIPTION
```
[1 of 8] Compiling Data.UUID.Named  ( Data/UUID/Named.hs, dist/dist-sandbox-81fa8808/build/Data/UUID/Named.o )

Data/UUID/Named.hs:50:17: Not in scope: `BL.fromStrict'
```

BL.toStrict is introduced in bytestring-0.10. 

P.S. Also made a revision on hackage: https://hackage.haskell.org/package/uuid-1.3.12/revisions/